### PR TITLE
Update React and React-DOM to version 19 for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
         "next": "^15.5.3",
         "next-themes": "^0.4.6",
         "qss": "^3.0.0",
-        "react": "^18.2.0",
+        "react": "^19.0.0",
         "react-day-picker": "^9.8.0",
-        "react-dom": "^18.2.0",
+        "react-dom": "^19.0.0",
         "react-dropzone": "^14.3.8",
         "react-fast-marquee": "^1.6.5",
         "react-hook-form": "^7.60.0",
@@ -97,6 +97,12 @@
         "three-globe": "^2.43.0",
         "vaul": "^1.1.2",
         "zod": "^4.1.8"
+    },
+    "overrides": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "@types/react": "^19",
+        "@types/react-dom": "^19"
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
Upgrade React and React-DOM to version 19 to ensure compatibility with the latest features and improvements for deployment on Vercel.